### PR TITLE
libcangjie2 was renamed to libcangjie

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,7 +12,7 @@ To build these bindings, you will need the following:
 * Python >= 3.2
 * Cython >= 0.17
 * a C compiler and library (we recommend GCC and the GNU C library)
-* the libcangjie2 library and development headers
+* the libcangjie library and development headers
 
 ### Install from a release tarball
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-This is a Python wrapper to libcangjie2, the library implementing the Cangjie
+This is a Python wrapper to libcangjie, the library implementing the Cangjie
 input method.
 
 Below is a trivial example of how to use it:

--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,7 @@ m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])])
 LT_INIT([disable-static])
 
 # Check for libcangjie
-PKG_CHECK_MODULES(LIBCANGJIE, [cangjie2 >= 0.0.0])
+PKG_CHECK_MODULES(LIBCANGJIE, [cangjie >= 0.0.0])
 
 # Check for Python 3
 AM_PATH_PYTHON([3.2.3])

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -9,12 +9,12 @@ sub: doc
 ## Exceptions
 
 pycangjie defines a set of exceptions mapping to the error codes returned by
-the libcangjie2 functions.
+the libcangjie functions.
 
 Functions which are supposed to get you a list of characters will raise
 `CangjieNoCharsError` when no characters correspond to your query.
 
-If the libcangjie2 database could not be opened for some reason, then
+If the libcangjie database could not be opened for some reason, then
 `CangjieDBOpenError` is raised.
 
 If an error happens when querying the database, the method will raise

--- a/docs/versions.md
+++ b/docs/versions.md
@@ -8,7 +8,7 @@ sub: doc
 
 ## The Cangjie versions
 
-libcangjie2 supports **2 different versions of the Cangjie input method**:
+libcangjie supports **2 different versions of the Cangjie input method**:
 versions 3 and 5.
 
 Obviously, so does pycangjie.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -64,7 +64,7 @@ class MetaTest(type):
 
 class BaseTestCase:
     """Base test class, grouping the common stuff for all our unit tests"""
-    cli_cmd = ["/usr/bin/libcangjie2_cli"]
+    cli_cmd = ["/usr/bin/libcangjie_cli"]
 
     def setUp(self):
         self.cj = cangjie.Cangjie(self.version, self.language)
@@ -81,7 +81,7 @@ class BaseTestCase:
         try:
             cangjie.errors.handle_error_code(proc.returncode,
                                              msg="Unknown error while running"
-                                                 " libcangjie2_cli (%d)"
+                                                 " libcangjie_cli (%d)"
                                                  % proc.returncode)
 
         except cangjie.errors.CangjieNoCharsError:
@@ -109,7 +109,7 @@ class BaseTestCase:
     def run_test(self, input_code):
         """Run the actual test
 
-        This compares the output of the libcangjie2_cli tool with the output
+        This compares the output of the libcangjie_cli tool with the output
         from pycangjie.
 
         The idea is that if pycangjie produces the same results as a C++ tool
@@ -119,9 +119,9 @@ class BaseTestCase:
         validity is to be checked in libcangjie.
 
         Note that this whole test is based on scraping the output of
-        libcangjie2_cli, which is quite fragile.
+        libcangjie_cli, which is quite fragile.
         """
-        # Get a list of CangjieChar from libcangjie2_cli as a reference
+        # Get a list of CangjieChar from libcangjie_cli as a reference
         tmp_expected = self.run_command(self.cli_cmd+[input_code]).split("\n")
         tmp_expected = map(lambda x: x.strip(" \n"), tmp_expected)
         tmp_expected = filter(lambda x: len(x) > 0, tmp_expected)

--- a/tests/test_cangjie.py
+++ b/tests/test_cangjie.py
@@ -25,7 +25,7 @@ from tests import BaseTestCase, MetaTest
 class VersionThreeBig5HKSCSTestCase(BaseTestCase, unittest.TestCase,
                                     metaclass=MetaTest):
     # For now, this is the only scenario we can test, as we rely on the
-    # libcangjie2_cli tool, and it only implements this
-    # FIXME: Improve libcangjie2_cli so we can cover other cases
+    # libcangjie_cli tool, and it only implements this
+    # FIXME: Improve libcangjie_cli so we can cover other cases
     version = cangjie.versions.CANGJIE3
     language = cangjie.filters.BIG5 | cangjie.filters.HKSCS


### PR DESCRIPTION
Just port over the rename.
