### PR TITLE
ci: Build against the 1.x branch of libcangjie

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_install:
   # First install libcangjie
   - sudo apt-get install libsqlite3-dev
   - git clone git://github.com/Cangjians/libcangjie
-  - cd libcangjie && ./autogen.sh --prefix=/usr && make && sudo make install && cd ..
+  - cd libcangjie && git checkout 1.x && ./autogen.sh --prefix=/usr && make && sudo make install && cd ..
   - git clean -dfx
 
   - sudo apt-get install python3-dev cython


### PR DESCRIPTION
libcangjie master broke its API, so we can't build the 1.x branch of
pycangjie against libcangjie master any more.

This is all perfectly expected though, but we need to tell Travis about
it.
