### PR TITLE
Remove obsolete notice

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -58,7 +58,9 @@ To build these bindings, you will need the following:
 
 ### Install from a release tarball
 
-_**Note:** There are no release tarballs at this point._
+Download a release tarball from
+[the download section](http://cangjians.github.io/downloads/pycangjie/) of
+our website.
 
 From the root folder of the unpacked tarball, do the usual Autotools dance:
 


### PR DESCRIPTION
We do have release tarballs, now.

Fixes #21
