### PR TITLE
Docker based testing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,49 @@
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.pyc
+*.pyo
+
+# Compiled Dynamic libraries
+*.so
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+
+# Generated source code
+*.c
+
+# Autotools stuff
+Makefile
+Makefile.in
+aclocal.m4
+autom4te.cache
+config.guess
+config.h
+config.h.in
+config.log
+config.status
+config.sub
+configure
+depcomp
+install-sh
+libtool
+ltmain.sh
+m4
+missing
+py-compile
+stamp-h1
+test-driver
+test-suite.log
+tests/*.log
+tests/*.trs
+tests/run_tests
+.deps
+.libs
+AUTHORS
+
+# Temp editor files
+*.swp

--- a/.dockerignore
+++ b/.dockerignore
@@ -47,3 +47,6 @@ AUTHORS
 
 # Temp editor files
 *.swp
+
+# Temp folder for depending repositories
+tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
   #- TARGET=local
   - TARGET=docker OS=ubuntu-16.04
   - TARGET=docker OS=fedora-25
+  - TARGET=docker OS=opensuse-leap
 before_install:
   - |
     # install packages for building pycangjie

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,46 @@
 language: c
+sudo: required
+services:
+  - docker
+env:
+  # prevent local build until issue #30 is resolved on Travis
+  # ref: https://github.com/Cangjians/pycangjie/issues/30
+  #- TARGET=local
+  - TARGET=docker
 before_install:
-  - sudo apt-get update
+  - |
+    # install packages for building pycangjie
+    if [ "${TARGET}" = "local" ]; then
+      sudo apt-get update
 
-  # First install libcangjie
-  - sudo apt-get install libsqlite3-dev
-  - git clone git://github.com/Cangjians/libcangjie
-  - cd libcangjie && git checkout master && ./autogen.sh --prefix=/usr && make && sudo make install && cd ..
-  - git clean -dfx
-
-  - sudo apt-get install python3-dev cython
-script: ./autogen.sh && make && make check && make distcheck
+      # First install libcangjie
+      sudo apt-get install libsqlite3-dev
+      git clone git://github.com/Cangjians/libcangjie
+      cd libcangjie && git checkout master && ./autogen.sh --prefix=/usr && make && sudo make install && cd ..
+      git clean -dfx
+      sudo apt-get install python3-dev cython
+    else
+      echo "skipped"
+    fi
+  - |
+    # build the docker image
+    if [ "${TARGET}" = "docker" ]; then
+      sudo docker build -t "cangjians/pycangjie" .
+    else
+      echo "skipped";
+    fi
+script:
+  - |
+    # build pycangjie
+    if [ "${TARGET}" = "local" ]; then
+      ./autogen.sh && make && make check && make distcheck
+    else
+      echo "skipped";
+    fi
+  - |
+    # test pycangjie in docker
+    if [ "${TARGET}" = "docker" ]; then
+      sudo docker run -it --rm "cangjians/pycangjie" make check distcheck
+    else
+      echo "skipped";
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ env:
   # prevent local build until issue #30 is resolved on Travis
   # ref: https://github.com/Cangjians/pycangjie/issues/30
   #- TARGET=local
-  - TARGET=docker
+  - TARGET=docker OS=ubuntu-16.04
+  - TARGET=docker OS=fedora-25
 before_install:
   - |
     # install packages for building pycangjie
@@ -25,6 +26,14 @@ before_install:
   - |
     # build the docker image
     if [ "${TARGET}" = "docker" ]; then
+      mkdir tmp
+      sudo docker pull "cangjians/build-essential:${OS}"
+      sudo docker tag "cangjians/build-essential:${OS}" "cangjians/build-essential:latest"
+      echo
+      echo OS=$(sudo docker run -it --rm "cangjians/build-essential:latest" -c "cat /var/version")
+      echo ---------------
+      git clone -b docker https://github.com/Cangjians/libcangjie.git tmp/libcangjie
+      sudo docker build -t "cangjians/libcangjie" tmp/libcangjie/.
       sudo docker build -t "cangjians/pycangjie" .
     else
       echo "skipped";

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM cangjians/libcangjie:latest
+MAINTAINER Cangjians (https://cangjians.github.io)
+
+# basic environment for building
+WORKDIR /usr/local/src/pycangjie
+
+# copy source files to build
+COPY "." "./"
+
+# build the library
+RUN ./autogen.sh --prefix=/usr && \
+  make && make install
+
+# manually adapt to Debian specific dist-packages practice
+RUN export PYTHONPATH=$(python3 -c "import os; print(os.path.dirname(os.__file__))") && \
+  mkdir -p $PYTHONPATH/dist-packages && \
+  ln -s $PYTHONPATH/site-packages/cangjie $PYTHONPATH/dist-packages/.
+
+ENTRYPOINT []
+CMD ["make", "check", "distcheck"]


### PR DESCRIPTION
1. Added Dockerfile to build docker image with pycangjie available as a system package.
  This enable docker based testing of ibus-cangjie.

2. Disables local Travis build to circumvent #30.

3. Added Docker based test in Travis.