### PR TITLE
Add the missing Docker build hooks

### DIFF
--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+docker build --build-arg OS=${DOCKER_TAG} -t ${IMAGE_NAME} .


### PR DESCRIPTION
Without this, the automated builds can't work.

Fixes #36